### PR TITLE
Solve "try" and "guard" tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     env:
       NAME: goldstein
     strategy:

--- a/packages/goldstein/index.spec.js
+++ b/packages/goldstein/index.spec.js
@@ -45,7 +45,7 @@ test('goldstein: compile: try', (t) => {
         tryCatch(hello, a, b, c);
     `;
     
-    t.equal(result, expected);
+    t.equal(toString(result), toString(expected));
     t.end();
 });
 

--- a/packages/goldstein/index.spec.js
+++ b/packages/goldstein/index.spec.js
@@ -32,7 +32,7 @@ test('goldstein: compile: guard', (t) => {
         }
     `;
     
-    t.equal(result, expected);
+    t.equal(toString(result), toString(expected));
     t.end();
 });
 


### PR DESCRIPTION
This solves "try" and "guard" compile test by "forcing" both codes to be a string.

All this is very strage because running the same tests doing a sort of debug printing (on the console), code and value types will result the same to eye and also by comparing them with VS Code built-in feature...
The strangest thing is also this code test (in "production" mode) [here](https://stackblitz.com/edit/node-zp6mh8?file=index.js): the result is both strings are equal, but that's not so by running tests.
All this should be investigated more, currently project tests could not be so reliable.