### PR TITLE
Add freeze keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,23 @@ try hello();
 
 > ☝️ *Warning: this feature can be helpful but also dangerous especially if you're debugging your application. In fact, this is made to be used as an optional function call (ex. should load content, but not necessary and knowing this feature is optional), if you call a function in this way while debugging, no error will be printed and the application will continue run as nothing happened.*
 
+### `freeze`
+
+You can use `freeze` instead of `Object.freeze()` like that:
+```gs
+freeze {
+    'example': true
+}
+```
+
+Is the same as:
+
+```js
+Object.freeze({
+    'example': true
+})
+```
+
 ### `if`
 
 You can omit parens. But you must use braces in this case.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ try hello();
 ### `freeze`
 
 You can use `freeze` instead of `Object.freeze()` like that:
+
 ```gs
 freeze {
     'example': true
@@ -179,8 +180,8 @@ Is the same as:
 
 ```js
 Object.freeze({
-    'example': true
-})
+    example: true,
+});
 ```
 
 ### `if`

--- a/packages/goldstein/index.js
+++ b/packages/goldstein/index.js
@@ -9,6 +9,7 @@ import keywordShould from '../keyword-should/index.js';
 import keywordThrow from '../keyword-throw/index.js';
 import stringInterpolation from '../string-interpolation/index.js';
 import keywordCurry from '../keyword-curry/index.js';
+import keywordFreeze from '../keyword-freeze/index.js';
 
 export const compile = (source) => {
     const {parse} = extendParser([
@@ -18,6 +19,7 @@ export const compile = (source) => {
         keywordShould,
         keywordThrow,
         keywordCurry,
+        keywordFreeze,
         stringInterpolation,
     ]);
     

--- a/packages/goldstein/index.spec.js
+++ b/packages/goldstein/index.spec.js
@@ -62,6 +62,20 @@ test('goldstein: compile: should', (t) => {
     t.end();
 });
 
+test('goldstein: compile: freeze', (t) => {
+    const result = compile(montag`
+        freeze {example: true}
+    `);
+    const expected = montag`
+        Object.freeze({
+            example: true
+        });;
+    `;
+    
+    t.equal(result, expected);
+    t.end();
+});
+
 test('goldstein: compile: sourceType', (t) => {
     const result = compile(montag`
         export fn hello() {};

--- a/packages/keyword-freeze/fixture/array-freeze.gs
+++ b/packages/keyword-freeze/fixture/array-freeze.gs
@@ -1,0 +1,8 @@
+freeze [
+    {
+        "test": true
+    },
+    {
+        "example": "Hello World!"
+    }
+]

--- a/packages/keyword-freeze/fixture/array-freeze.js
+++ b/packages/keyword-freeze/fixture/array-freeze.js
@@ -1,0 +1,5 @@
+Object.freeze([{
+    'test': true
+}, {
+    'example': 'Hello World!'
+}]);;

--- a/packages/keyword-freeze/fixture/freeze.gs
+++ b/packages/keyword-freeze/fixture/freeze.gs
@@ -1,0 +1,3 @@
+freeze {
+    "test": true
+}

--- a/packages/keyword-freeze/fixture/freeze.js
+++ b/packages/keyword-freeze/fixture/freeze.js
@@ -1,0 +1,3 @@
+Object.freeze({
+    'test': true
+});;

--- a/packages/keyword-freeze/fixture/not-supported.gs
+++ b/packages/keyword-freeze/fixture/not-supported.gs
@@ -1,0 +1,1 @@
+freeze true

--- a/packages/keyword-freeze/index.js
+++ b/packages/keyword-freeze/index.js
@@ -1,0 +1,68 @@
+import {types} from 'putout';
+import {
+    addKeyword,
+    TokenType,
+    tokTypes as tt,
+} from '../operator/index.js';
+
+const {
+    isObjectExpression,
+    isArrayExpression
+} = types;
+
+export default function newSpeak(Parser) {
+    const {keywordTypes} = Parser.acorn;
+    keywordTypes.freeze = new TokenType('freeze', {
+        keyword: 'freeze',
+    });
+    
+    return class extends Parser {
+        parse() {
+            this.keywords = addKeyword('freeze', this.keywords);
+            return super.parse();
+        }
+        parseStatement(context, topLevel, exports) {
+            if (this.type === keywordTypes.freeze) {
+                return this.parseFreeze();
+            }
+            
+            return super.parseStatement(context, topLevel, exports);
+        }
+        
+        parseFreeze() {
+            this.next();
+            
+            const node = super.startNode();
+            const expression = this.parseExpression();
+            
+            if (isObjectExpression(expression) || isArrayExpression(expression))
+                node.expression = {
+                    "type": "ExpressionStatement",
+                    "expression": {
+                        "type": "CallExpression",
+                        "callee": {
+                            "type": "MemberExpression",
+                            "object": {
+                                "type": "Identifier",
+                                "name": "Object"
+                            },
+                            "property": {
+                                "type": "Identifier",
+                                "name": "freeze"
+                            },
+                            "computed": false
+                        },
+                        "arguments": [
+                            expression
+                        ]
+                    }
+                }
+                
+            else
+                this.raise(this.start, `After 'freeze' only objects and arrays can come`);
+            
+            return super.finishNode(node, 'ExpressionStatement');
+        }
+    };
+}
+

--- a/packages/keyword-freeze/index.js
+++ b/packages/keyword-freeze/index.js
@@ -2,12 +2,11 @@ import {types} from 'putout';
 import {
     addKeyword,
     TokenType,
-    tokTypes as tt,
 } from '../operator/index.js';
 
 const {
     isObjectExpression,
-    isArrayExpression
+    isArrayExpression,
 } = types;
 
 export default function newSpeak(Parser) {
@@ -37,27 +36,27 @@ export default function newSpeak(Parser) {
             
             if (isObjectExpression(expression) || isArrayExpression(expression))
                 node.expression = {
-                    "type": "ExpressionStatement",
-                    "expression": {
-                        "type": "CallExpression",
-                        "callee": {
-                            "type": "MemberExpression",
-                            "object": {
-                                "type": "Identifier",
-                                "name": "Object"
+                    type: 'ExpressionStatement',
+                    expression: {
+                        type: 'CallExpression',
+                        callee: {
+                            type: 'MemberExpression',
+                            object: {
+                                type: 'Identifier',
+                                name: 'Object',
                             },
-                            "property": {
-                                "type": "Identifier",
-                                "name": "freeze"
+                            property: {
+                                type: 'Identifier',
+                                name: 'freeze',
                             },
-                            "computed": false
+                            computed: false,
                         },
-                        "arguments": [
-                            expression
-                        ]
-                    }
-                }
-                
+                        arguments: [
+                            expression,
+                        ],
+                    },
+                };
+            
             else
                 this.raise(this.start, `After 'freeze' only objects and arrays can come`);
             

--- a/packages/keyword-freeze/index.spec.js
+++ b/packages/keyword-freeze/index.spec.js
@@ -13,7 +13,7 @@ test('goldstein: keyword: freeze (using array)', (t) => {
     t.end();
 });
 
-test('goldstein: keyword: should (invalid)', (t) => {
+test('goldstein: keyword: freeze (invalid)', (t) => {
     t.raise('not-supported', `After 'freeze' only objects and arrays can come (1:11)`);
     t.end();
 });

--- a/packages/keyword-freeze/index.spec.js
+++ b/packages/keyword-freeze/index.spec.js
@@ -1,0 +1,19 @@
+import {createTest} from '../test/index.js';
+import keywordFn from './index.js';
+
+const test = createTest(import.meta.url, keywordFn);
+
+test('goldstein: keyword: freeze', (t) => {
+    t.compile('freeze');
+    t.end();
+});
+
+test('goldstein: keyword: freeze (using array)', (t) => {
+    t.compile('array-freeze');
+    t.end();
+});
+
+test('goldstein: keyword: should (invalid)', (t) => {
+    t.raise('not-supported', `After 'freeze' only objects and arrays can come (1:11)`);
+    t.end();
+});


### PR DESCRIPTION
This pull adds the `freeze` keyword.
***
## About (same as README.md)
### `freeze`

You can use `freeze` instead of `Object.freeze()` like that:
```gs
freeze {
    'example': true
}
```

Is the same as:

```js
Object.freeze({
    'example': true
})
```
***
@coderaiser, seems there is a little thing goes bad while compiling: the compiled code adds two semicolons instead of one. I don't know if there is something to change in my code... Anyways the produced code doesn't produce any error at execution time and could also be left so (it's always a compiled code...).